### PR TITLE
Fix layout, scrolling, and display issues

### DIFF
--- a/components/filters.html
+++ b/components/filters.html
@@ -99,9 +99,9 @@
             <input id="splitB" type="range" min="0" max="100" step="1" value="66" />
           </div>
           <div class="chipsRow">
-            <span class="chip">Горы: <span id="ratioH">33</span>%</span>
-            <span class="chip">Океаны: <span id="ratioO">33</span>%</span>
-            <span class="chip">Равнины: <span id="ratioP">34</span>%</span>
+            <span class="chip">Горы: <span id="ratioH">33%</span></span>
+            <span class="chip">Океаны: <span id="ratioO">33%</span></span>
+            <span class="chip">Равнины: <span id="ratioP">34%</span></span>
           </div>
           <label>Строгость поиска (0–100%): <input id="ratioSim" type="range" min="0" max="100" step="1" value="0" /> <span id="ratioSimVal">0</span>%</label>
           <div class="small muted">Если строгость = 0%, фильтр не применяется.</div>

--- a/js/filters.js
+++ b/js/filters.js
@@ -253,9 +253,9 @@ export function initFilters() {
               P = Math.round(100 - B);
         fill.style.left = A + '%';
         fill.style.right = (100 - B) + '%';
-        outH.textContent = H;
-        outO.textContent = O;
-        outP.textContent = P;
+        outH.textContent = H + '%';
+        outO.textContent = O + '%';
+        outP.textContent = P + '%';
         STATE.ratio = { h: H, o: O, p: P };
     }
     a.addEventListener('input', updateDouble);


### PR DESCRIPTION
This commit resolves several UI problems and adds a specific workaround for a rendering bug in Blink-based browsers.

In the "Search" panel:
- Child elements in the "Uninhabited Planets" section are resized to prevent overflow.
- The "Search Strictness" slider is made full-width.
- The percentage values in the ratio slider are now formatted without a space before the '%' sign to prevent unwanted line breaks.

A z-index stacking context is created to ensure side panels render above the central map panel, fixing a clipping issue in Chrome Canary.

The details/results panel is configured to scroll correctly, and a `will-change` property is added to hint at layer promotion for the browser, further preventing rendering glitches.